### PR TITLE
Fix syntax in example code for loading the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a major mode for emacs that highlights the Coconut language
 
 To load it, put the `coconut-mode.el` file somewhere safe and
-do a `(load-file /path/to/coconut-mode.el)` in your `init.el`.
+do a `(load-file "/path/to/coconut-mode.el")` in your `init.el`.
 
 ## TODO:
 - Upload to Melpa


### PR DESCRIPTION
Obviously this is a trivial issue, but it tripped me up when trying to use the library myself, so I figured it was worth fixing.